### PR TITLE
Revert "DTSPO-8697 - Test with private acr"

### DIFF
--- a/charts/toffee-frontend/Chart.yaml
+++ b/charts/toffee-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 name: toffee-frontend
 apiVersion: v2
 home: https://github.com/hmcts/sds-toffee-frontend
-version: 0.1.11
+version: 0.1.12
 description: HMCTS Toffee frontend application (test application)
 maintainers:
   - name: HMCTS Platform Engineering Team

--- a/charts/toffee-frontend/Chart.yaml
+++ b/charts/toffee-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 name: toffee-frontend
 apiVersion: v2
 home: https://github.com/hmcts/sds-toffee-frontend
-version: 0.1.12
+version: 0.1.13
 description: HMCTS Toffee frontend application (test application)
 maintainers:
   - name: HMCTS Platform Engineering Team

--- a/charts/toffee-frontend/Chart.yaml
+++ b/charts/toffee-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 name: toffee-frontend
 apiVersion: v2
 home: https://github.com/hmcts/sds-toffee-frontend
-version: 0.1.12
+version: 0.1.11
 description: HMCTS Toffee frontend application (test application)
 maintainers:
   - name: HMCTS Platform Engineering Team

--- a/charts/toffee-frontend/values.yaml
+++ b/charts/toffee-frontend/values.yaml
@@ -1,6 +1,6 @@
 nodejs:
   applicationPort: 1337
-  image: 'sdshmctsprivate.azurecr.io/toffee/frontend:ek-test-4'
+  image: 'sdshmctspublic.azurecr.io/toffee/frontend:latest'
   aadIdentityName: toffee
   environment:
     RECIPE_BACKEND_URL: http://plum-recipe-backend-java


### PR DESCRIPTION
Reverts hmcts/sds-toffee-frontend#49

Pulling from private acr is working on both dev and prod clusters so this can be reverted