### PR TITLE
Test minimum age config in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>hmcts/.github//renovate/automerge-all", "local>hmcts/.github:renovate-config"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "matchPackageNames": ["copy-webpack-plugin"],


### PR DESCRIPTION
### Jira link

See [DTSPO-31517](https://tools.hmcts.net/jira/browse/DTSPO-31517)

### Change description

Testing minimum release age config in renovate
This is to force renovate to wait for a period of time before creating PRs
This is designed to reduce the risk associated with supply chain attacks

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
