### PR TITLE
Set npmMinimalAgeGate in yarnrc

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ enableGlobalCache: false
 nodeLinker: pnp
 
 yarnPath: .yarn/releases/yarn-4.6.0.cjs
+
+npmMinimalAgeGate: "7d"


### PR DESCRIPTION
### Jira link

See [DTSPO-31517](https://tools.hmcts.net/jira/browse/DTSPO-31517)

### Change description

Set `npmMinimalAgeGate` in yarnrc
Renovate isn't picking up the values for npm which may be expected behaviour going by the docs
They advise using their settings in conjunction with package manager settings

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
