### PR TITLE
Enable security scan in nightly pipeline

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -13,4 +13,5 @@ def component = "frontend"
 
 withNightlyPipeline(type, product, component) {
   env.TEST_URL = "https://toffee.sandbox.platform.hmcts.net/"
+  enableSecurityScan()
 }


### PR DESCRIPTION
Testing this out as I haven't found any SDS services with the security scan enabled, only CFT, so just making sure this is still right/working before I ask a team to enable this to give me some comparison results for a DAST tool CoE are looking into.

A [pr was closed](https://github.com/hmcts/sds-toffee-frontend/pull/119) for this a long while back.