### PR TITLE
Update Jenkins library to 2.2.0

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@DTSPO-30107-jenkins-agents")
+@Library("Infrastructure@2.2.0")
 
 def type = "nodejs"
 def product = "toffee"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -5,7 +5,7 @@ properties([
   pipelineTriggers([cron('H 08 * * 1-5')])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.2.0")
 
 def type = "nodejs"
 def product = "toffee"

--- a/yarn-audit-known-issues
+++ b/yarn-audit-known-issues
@@ -1,41 +1,83 @@
-{"value":"@opentelemetry/exporter-prometheus","children":{"ID":1117943,"Issue":"Prometheus exporter process crash via malformed HTTP request","URL":"https://github.com/advisories/GHSA-q7rr-3cgh-j5r3","Severity":"high","Vulnerable Versions":"<0.217.0","Tree Versions":["0.57.2"],"Dependents":["@opentelemetry/sdk-node@virtual:6bb62aed1afba9c6b82ac94c5f1ec9273b9b1eac1dbcf9b8df8f6c315858dd34263c4c5ae6ad65b497f77a99035247cc7e8f16057d0ae081da9b8a81bcda2575#npm:0.57.2"]}}
-{"value":"@opentelemetry/sdk-node","children":{"ID":1117942,"Issue":"Prometheus exporter process crash via malformed HTTP request","URL":"https://github.com/advisories/GHSA-q7rr-3cgh-j5r3","Severity":"high","Vulnerable Versions":"<0.217.0","Tree Versions":["0.57.2"],"Dependents":["@azure/monitor-opentelemetry@npm:1.8.1"]}}
-{"value":"@tootallnate/once","children":{"ID":1113977,"Issue":"@tootallnate/once vulnerable to Incorrect Control Flow Scoping","URL":"https://github.com/advisories/GHSA-vpq2-c234-7xj6","Severity":"low","Vulnerable Versions":"<3.0.1","Tree Versions":["2.0.0"],"Dependents":["http-proxy-agent@npm:5.0.0"]}}
-{"value":"ajv","children":{"ID":1113715,"Issue":"ajv has ReDoS when using `$data` option","URL":"https://github.com/advisories/GHSA-2g4f-4pwh-qvx6","Severity":"moderate","Vulnerable Versions":">=7.0.0-alpha.0 <8.18.0","Tree Versions":["8.12.0"],"Dependents":["table@npm:6.8.2"]}}
-{"value":"braces","children":{"ID":1098094,"Issue":"Uncontrolled resource consumption in braces","URL":"https://github.com/advisories/GHSA-grv7-fg5c-xmjg","Severity":"high","Vulnerable Versions":"<3.0.3","Tree Versions":["3.0.2"],"Dependents":["micromatch@npm:4.0.5"]}}
-{"value":"cross-spawn","children":{"ID":1104664,"Issue":"Regular Expression Denial of Service (ReDoS) in cross-spawn","URL":"https://github.com/advisories/GHSA-3xgq-45jj-v275","Severity":"high","Vulnerable Versions":">=7.0.0 <7.0.5","Tree Versions":["7.0.3"],"Dependents":["foreground-child@npm:3.1.1"]}}
-{"value":"diff","children":{"ID":1112704,"Issue":"jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch","URL":"https://github.com/advisories/GHSA-73rr-hh4g-fpgx","Severity":"low","Vulnerable Versions":">=4.0.0 <4.0.4","Tree Versions":["4.0.2"],"Dependents":["ts-node@virtual:9201c3fcb1d2fc337a547d3e1e1ecdada20d4bdb2e59c3be026997a45afd9453374b37c3a876bd411e30a3314956039c4ef01c63ae83dddfcd7fe8ddf8896a6d#npm:10.9.2"]}}
-{"value":"flatted","children":{"ID":1114526,"Issue":"flatted vulnerable to unbounded recursion DoS in parse() revive phase","URL":"https://github.com/advisories/GHSA-25h7-pfq9-p65f","Severity":"high","Vulnerable Versions":"<3.4.0","Tree Versions":["3.3.1"],"Dependents":["flat-cache@npm:5.0.0"]}}
-{"value":"flatted","children":{"ID":1115357,"Issue":"Prototype Pollution via parse() in NodeJS flatted","URL":"https://github.com/advisories/GHSA-rf6f-7fwh-wjgh","Severity":"high","Vulnerable Versions":"<=3.4.1","Tree Versions":["3.3.1"],"Dependents":["flat-cache@npm:5.0.0"]}}
-{"value":"form-data","children":{"ID":1109538,"Issue":"form-data uses unsafe random function in form-data for choosing boundary","URL":"https://github.com/advisories/GHSA-fjxv-7rqg-78g4","Severity":"critical","Vulnerable Versions":">=4.0.0 <4.0.4","Tree Versions":["4.0.0"],"Dependents":["superagent@npm:10.2.2"]}}
-{"value":"glob","children":{"ID":1109842,"Issue":"glob CLI: Command injection via -c/--cmd executes matches with shell:true","URL":"https://github.com/advisories/GHSA-5j98-mcp5-4vw2","Severity":"high","Vulnerable Versions":">=10.2.0 <10.5.0","Tree Versions":["10.4.5"],"Dependents":["node-gyp@npm:10.0.1"]}}
-{"value":"glob","children":{"ID":"glob (deprecation)","Issue":"Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me","Severity":"moderate","Vulnerable Versions":"11.1.0","Tree Versions":["11.1.0"],"Dependents":["sds-toffee-frontend@workspace:."]}}
-{"value":"ip-address","children":{"ID":1118827,"Issue":"ip-address has XSS in Address6 HTML-emitting methods","URL":"https://github.com/advisories/GHSA-v2v4-37r5-5v8g","Severity":"moderate","Vulnerable Versions":"<=10.1.0","Tree Versions":["9.0.5"],"Dependents":["socks@npm:2.8.1"]}}
-{"value":"js-yaml","children":{"ID":1112715,"Issue":"js-yaml has prototype pollution in merge (<<)","URL":"https://github.com/advisories/GHSA-mh29-5h37-fv8m","Severity":"moderate","Vulnerable Versions":">=4.0.0 <4.1.1","Tree Versions":["4.1.0"],"Dependents":["@hmcts/info-provider@npm:1.2.2"]}}
-{"value":"jws","children":{"ID":1111243,"Issue":"auth0/node-jws Improperly Verifies HMAC Signature","URL":"https://github.com/advisories/GHSA-869p-cjfg-cm3x","Severity":"high","Vulnerable Versions":"=4.0.0","Tree Versions":["4.0.0"],"Dependents":["@azure/identity@npm:4.4.0"]}}
-{"value":"jws","children":{"ID":1111244,"Issue":"auth0/node-jws Improperly Verifies HMAC Signature","URL":"https://github.com/advisories/GHSA-869p-cjfg-cm3x","Severity":"high","Vulnerable Versions":"<3.2.3","Tree Versions":["3.2.2"],"Dependents":["jsonwebtoken@npm:9.0.2"]}}
-{"value":"lodash","children":{"ID":1112455,"Issue":"Lodash has Prototype Pollution Vulnerability in `_.unset` and `_.omit` functions","URL":"https://github.com/advisories/GHSA-xxjr-mmjv-4gpg","Severity":"moderate","Vulnerable Versions":">=4.0.0 <=4.17.22","Tree Versions":["4.17.21"],"Dependents":["sds-toffee-frontend@workspace:."]}}
-{"value":"lodash","children":{"ID":1115806,"Issue":"lodash vulnerable to Code Injection via `_.template` imports key names","URL":"https://github.com/advisories/GHSA-r5fr-rjxr-66jc","Severity":"high","Vulnerable Versions":">=4.0.0 <=4.17.23","Tree Versions":["4.17.21"],"Dependents":["sds-toffee-frontend@workspace:."]}}
-{"value":"lodash","children":{"ID":1115810,"Issue":"lodash vulnerable to Prototype Pollution via array path bypass in `_.unset` and `_.omit`","URL":"https://github.com/advisories/GHSA-f23m-r3pf-42rh","Severity":"moderate","Vulnerable Versions":"<=4.17.23","Tree Versions":["4.17.21"],"Dependents":["sds-toffee-frontend@workspace:."]}}
-{"value":"micromatch","children":{"ID":1098681,"Issue":"Regular Expression Denial of Service (ReDoS) in micromatch","URL":"https://github.com/advisories/GHSA-952p-6rrq-rcjv","Severity":"moderate","Vulnerable Versions":"<4.0.8","Tree Versions":["4.0.5"],"Dependents":["fast-glob@npm:3.3.2"]}}
-{"value":"nanoid","children":{"ID":1109563,"Issue":"Predictable results in nanoid generation when given non-integer values","URL":"https://github.com/advisories/GHSA-mwcw-c2x4-8c55","Severity":"moderate","Vulnerable Versions":"<3.3.8","Tree Versions":["3.3.7"],"Dependents":["postcss@npm:8.4.49"]}}
-{"value":"path-to-regexp","children":{"ID":1115527,"Issue":"path-to-regexp vulnerable to Regular Expression Denial of Service via multiple route parameters","URL":"https://github.com/advisories/GHSA-37ch-88jc-xwx2","Severity":"high","Vulnerable Versions":"<0.1.13","Tree Versions":["0.1.12"],"Dependents":["express@npm:4.21.2"]}}
-{"value":"picomatch","children":{"ID":1115549,"Issue":"Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching","URL":"https://github.com/advisories/GHSA-3v7f-55p6-f55p","Severity":"moderate","Vulnerable Versions":"<2.3.2","Tree Versions":["2.3.1"],"Dependents":["micromatch@npm:4.0.8"]}}
-{"value":"picomatch","children":{"ID":1115552,"Issue":"Picomatch has a ReDoS vulnerability via extglob quantifiers","URL":"https://github.com/advisories/GHSA-c2c7-rcm5-vvqj","Severity":"high","Vulnerable Versions":"<2.3.2","Tree Versions":["2.3.1"],"Dependents":["micromatch@npm:4.0.8"]}}
-{"value":"postcss","children":{"ID":1117015,"Issue":"PostCSS has XSS via Unescaped </style> in its CSS Stringify Output","URL":"https://github.com/advisories/GHSA-qx2v-qp2m-jg93","Severity":"moderate","Vulnerable Versions":"<8.5.10","Tree Versions":["8.4.49"],"Dependents":["stylelint@npm:16.11.0"]}}
-{"value":"qs","children":{"ID":1113161,"Issue":"qs's arrayLimit bypass in comma parsing allows denial of service","URL":"https://github.com/advisories/GHSA-w7fw-mjwx-w883","Severity":"low","Vulnerable Versions":">=6.7.0 <=6.14.1","Tree Versions":["6.13.1"],"Dependents":["body-parser@npm:1.20.3"]}}
-{"value":"qs","children":{"ID":1113719,"Issue":"qs's arrayLimit bypass in its bracket notation allows DoS via memory exhaustion","URL":"https://github.com/advisories/GHSA-6rw7-vpxm-498p","Severity":"moderate","Vulnerable Versions":"<6.14.1","Tree Versions":["6.13.1"],"Dependents":["body-parser@npm:1.20.3"]}}
-{"value":"tar","children":{"ID":1097493,"Issue":"Denial of service while parsing a tar file due to lack of folders count validation","URL":"https://github.com/advisories/GHSA-f5x3-32g6-xq36","Severity":"moderate","Vulnerable Versions":"<6.2.1","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
-{"value":"tar","children":{"ID":1112659,"Issue":"node-tar Vulnerable to Arbitrary File Creation/Overwrite via Hardlink Path Traversal","URL":"https://github.com/advisories/GHSA-34x7-hfp2-rc4v","Severity":"high","Vulnerable Versions":"<7.5.7","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
-{"value":"tar","children":{"ID":1113300,"Issue":"node-tar is Vulnerable to Arbitrary File Overwrite and Symlink Poisoning via Insufficient Path Sanitization","URL":"https://github.com/advisories/GHSA-8qq5-rm4j-mr97","Severity":"high","Vulnerable Versions":"<=7.5.2","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
-{"value":"tar","children":{"ID":1113375,"Issue":"Arbitrary File Read/Write via Hardlink Target Escape Through Symlink Chain in node-tar Extraction","URL":"https://github.com/advisories/GHSA-83g3-92jg-28cx","Severity":"high","Vulnerable Versions":"<7.5.8","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
-{"value":"tar","children":{"ID":1114200,"Issue":"tar has Hardlink Path Traversal via Drive-Relative Linkpath","URL":"https://github.com/advisories/GHSA-qffp-2rhf-9h96","Severity":"high","Vulnerable Versions":"<=7.5.9","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
-{"value":"tar","children":{"ID":1114302,"Issue":"node-tar Symlink Path Traversal via Drive-Relative Linkpath","URL":"https://github.com/advisories/GHSA-9ppj-qmqm-q256","Severity":"high","Vulnerable Versions":"<=7.5.10","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
-{"value":"tar","children":{"ID":1114680,"Issue":"Race Condition in node-tar Path Reservations via Unicode Ligature Collisions on macOS APFS","URL":"https://github.com/advisories/GHSA-r6q2-hw4h-h46w","Severity":"high","Vulnerable Versions":"<=7.5.3","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
-{"value":"undici","children":{"ID":1112496,"Issue":"Undici has an unbounded decompression chain in HTTP responses on Node.js Fetch API via Content-Encoding leads to resource exhaustion","URL":"https://github.com/advisories/GHSA-g9mf-h72j-4rw9","Severity":"moderate","Vulnerable Versions":"<6.23.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
-{"value":"undici","children":{"ID":1113069,"Issue":"undici Denial of Service attack via bad certificate data","URL":"https://github.com/advisories/GHSA-cxrh-j4jr-qwg3","Severity":"low","Vulnerable Versions":"<5.29.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
-{"value":"undici","children":{"ID":1114594,"Issue":"Undici has an HTTP Request/Response Smuggling issue","URL":"https://github.com/advisories/GHSA-2mjp-6q6p-2qxm","Severity":"moderate","Vulnerable Versions":"<6.24.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
-{"value":"undici","children":{"ID":1114638,"Issue":"Undici has Unbounded Memory Consumption in WebSocket permessage-deflate Decompression","URL":"https://github.com/advisories/GHSA-vrm6-8vpv-qv8q","Severity":"high","Vulnerable Versions":"<6.24.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
-{"value":"undici","children":{"ID":1114640,"Issue":"Undici has Unhandled Exception in WebSocket Client Due to Invalid server_max_window_bits Validation","URL":"https://github.com/advisories/GHSA-v9p9-hfj2-hcw8","Severity":"high","Vulnerable Versions":"<6.24.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
-{"value":"undici","children":{"ID":1114642,"Issue":"Undici has CRLF Injection in undici via `upgrade` option","URL":"https://github.com/advisories/GHSA-4992-7rv2-5pvq","Severity":"moderate","Vulnerable Versions":"<6.24.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
-{"value":"uuid","children":{"ID":"uuid (deprecation)","Issue":"uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).","Severity":"moderate","Vulnerable Versions":"8.3.2","Tree Versions":["8.3.2"],"Dependents":["@azure/functions@npm:3.5.1"]}}
+{
+  "actions": [],
+  "advisories": {
+    "1120792": {
+      "access": "public",
+      "created": null,
+      "cves": [],
+      "cvss": [],
+      "cwe": [],
+      "deleted": null,
+      "findings": [
+        {
+          "paths": [
+            "sds-toffee-frontend@workspace:."
+          ],
+          "version": "4.1.1"
+        }
+      ],
+      "found_by": null,
+      "github_advisory_id": null,
+      "id": 1120792,
+      "metadata": null,
+      "module_name": "js-yaml",
+      "npm_advisory_id": null,
+      "overview": "JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases",
+      "patched_versions": null,
+      "recommendation": null,
+      "references": "",
+      "reported_by": null,
+      "severity": "moderate",
+      "title": "Could not fetch GitHub Advisory; ResultCode: 401, Body: {\r\n  \"message\": \"Bad credentials\",\r\n  \"documentation_url\": \"https://docs.github.com/rest\",\r\n  \"status\": \"401\"\r\n}",
+      "updated": null,
+      "url": null,
+      "vulnerable_versions": "<=4.1.1"
+    },
+    "glob (deprecation)": {
+      "access": "public",
+      "created": null,
+      "cves": [],
+      "cvss": [],
+      "cwe": [],
+      "deleted": null,
+      "findings": [
+        {
+          "paths": [
+            "sds-toffee-frontend@workspace:."
+          ],
+          "version": "11.1.0"
+        }
+      ],
+      "found_by": null,
+      "github_advisory_id": null,
+      "id": "glob (deprecation)",
+      "metadata": null,
+      "module_name": "glob",
+      "npm_advisory_id": null,
+      "overview": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "patched_versions": null,
+      "recommendation": null,
+      "references": "",
+      "reported_by": null,
+      "severity": "moderate",
+      "title": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "updated": null,
+      "url": null,
+      "vulnerable_versions": "11.1.0"
+    }
+  },
+  "metadata": {
+    "dependencies": 1511,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 1511,
+    "vulnerabilities": {
+      "critical": 0,
+      "high": 0,
+      "info": 0,
+      "low": 0,
+      "moderate": 2
+    }
+  },
+  "muted": []
+}

--- a/yarn-audit-known-issues
+++ b/yarn-audit-known-issues
@@ -1,83 +1,51 @@
-{
-  "actions": [],
-  "advisories": {
-    "1120792": {
-      "access": "public",
-      "created": null,
-      "cves": [],
-      "cvss": [],
-      "cwe": [],
-      "deleted": null,
-      "findings": [
-        {
-          "paths": [
-            "sds-toffee-frontend@workspace:."
-          ],
-          "version": "4.1.1"
-        }
-      ],
-      "found_by": null,
-      "github_advisory_id": null,
-      "id": 1120792,
-      "metadata": null,
-      "module_name": "js-yaml",
-      "npm_advisory_id": null,
-      "overview": "JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases",
-      "patched_versions": null,
-      "recommendation": null,
-      "references": "",
-      "reported_by": null,
-      "severity": "moderate",
-      "title": "Could not fetch GitHub Advisory; ResultCode: 401, Body: {\r\n  \"message\": \"Bad credentials\",\r\n  \"documentation_url\": \"https://docs.github.com/rest\",\r\n  \"status\": \"401\"\r\n}",
-      "updated": null,
-      "url": null,
-      "vulnerable_versions": "<=4.1.1"
-    },
-    "glob (deprecation)": {
-      "access": "public",
-      "created": null,
-      "cves": [],
-      "cvss": [],
-      "cwe": [],
-      "deleted": null,
-      "findings": [
-        {
-          "paths": [
-            "sds-toffee-frontend@workspace:."
-          ],
-          "version": "11.1.0"
-        }
-      ],
-      "found_by": null,
-      "github_advisory_id": null,
-      "id": "glob (deprecation)",
-      "metadata": null,
-      "module_name": "glob",
-      "npm_advisory_id": null,
-      "overview": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "patched_versions": null,
-      "recommendation": null,
-      "references": "",
-      "reported_by": null,
-      "severity": "moderate",
-      "title": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "updated": null,
-      "url": null,
-      "vulnerable_versions": "11.1.0"
-    }
-  },
-  "metadata": {
-    "dependencies": 1511,
-    "devDependencies": 0,
-    "optionalDependencies": 0,
-    "totalDependencies": 1511,
-    "vulnerabilities": {
-      "critical": 0,
-      "high": 0,
-      "info": 0,
-      "low": 0,
-      "moderate": 2
-    }
-  },
-  "muted": []
-}
+{"value":"@grpc/grpc-js","children":{"ID":1120585,"Issue":"@grpc/grpc-js: A malformed request can cause a server crash","URL":"https://github.com/advisories/GHSA-5375-pq7m-f5r2","Severity":"high","Vulnerable Versions":">=1.11.0 <1.11.4","Tree Versions":["1.11.1"],"Dependents":["@opentelemetry/exporter-logs-otlp-grpc@virtual:414e3ef9f066c7ecc00bc3855b56b0a2d6e9591e6e6e8ef8a2fc686a688311e2a5657ecef660c8deb29cc73a8f6f8adb98dac841a0862569c50489f1afbf6ced#npm:0.57.2"]}}
+{"value":"@grpc/grpc-js","children":{"ID":1120591,"Issue":"@grpc/grpc-js: An incoming malformed compressed message can cause a client or server crash","URL":"https://github.com/advisories/GHSA-99f4-grh7-6pcq","Severity":"high","Vulnerable Versions":">=1.11.0 <1.11.4","Tree Versions":["1.11.1"],"Dependents":["@opentelemetry/exporter-logs-otlp-grpc@virtual:414e3ef9f066c7ecc00bc3855b56b0a2d6e9591e6e6e8ef8a2fc686a688311e2a5657ecef660c8deb29cc73a8f6f8adb98dac841a0862569c50489f1afbf6ced#npm:0.57.2"]}}
+{"value":"@opentelemetry/core","children":{"ID":1120821,"Issue":"OpenTelemetry Core: Unbounded memory allocation in W3C Baggage propagation","URL":"https://github.com/advisories/GHSA-8988-4f7v-96qf","Severity":"moderate","Vulnerable Versions":"<2.8.0","Tree Versions":["1.22.0","1.25.1","1.26.0","1.30.1"],"Dependents":["@azure/opentelemetry-instrumentation-azure-sdk@npm:1.0.0-beta.5","@opentelemetry/resource-detector-azure@virtual:6bb62aed1afba9c6b82ac94c5f1ec9273b9b1eac1dbcf9b8df8f6c315858dd34263c4c5ae6ad65b497f77a99035247cc7e8f16057d0ae081da9b8a81bcda2575#npm:0.6.0","@opentelemetry/sql-common@virtual:fda9ed537954d49d37c25a396f33d5b0405b51fa0451eed3f8f57bc8d9eeb7c45bb78d52765f03ed4dead0eb6b3de90814665e7ddc5366e1e286d85e973fa54f#npm:0.40.1","applicationinsights@npm:3.5.0"]}}
+{"value":"@opentelemetry/exporter-prometheus","children":{"ID":1120253,"Issue":"Prometheus exporter process crash via malformed HTTP request","URL":"https://github.com/advisories/GHSA-q7rr-3cgh-j5r3","Severity":"high","Vulnerable Versions":"<0.217.0","Tree Versions":["0.57.2"],"Dependents":["@opentelemetry/sdk-node@virtual:6bb62aed1afba9c6b82ac94c5f1ec9273b9b1eac1dbcf9b8df8f6c315858dd34263c4c5ae6ad65b497f77a99035247cc7e8f16057d0ae081da9b8a81bcda2575#npm:0.57.2"]}}
+{"value":"@opentelemetry/sdk-node","children":{"ID":1120252,"Issue":"Prometheus exporter process crash via malformed HTTP request","URL":"https://github.com/advisories/GHSA-q7rr-3cgh-j5r3","Severity":"high","Vulnerable Versions":"<0.217.0","Tree Versions":["0.57.2"],"Dependents":["@azure/monitor-opentelemetry@npm:1.8.1"]}}
+{"value":"@tootallnate/once","children":{"ID":1119438,"Issue":"@tootallnate/once vulnerable to Incorrect Control Flow Scoping","URL":"https://github.com/advisories/GHSA-vpq2-c234-7xj6","Severity":"low","Vulnerable Versions":"<2.0.1","Tree Versions":["2.0.0"],"Dependents":["http-proxy-agent@npm:5.0.0"]}}
+{"value":"ajv","children":{"ID":1113715,"Issue":"ajv has ReDoS when using `$data` option","URL":"https://github.com/advisories/GHSA-2g4f-4pwh-qvx6","Severity":"moderate","Vulnerable Versions":">=7.0.0-alpha.0 <8.18.0","Tree Versions":["8.12.0"],"Dependents":["table@npm:6.8.2"]}}
+{"value":"braces","children":{"ID":1098094,"Issue":"Uncontrolled resource consumption in braces","URL":"https://github.com/advisories/GHSA-grv7-fg5c-xmjg","Severity":"high","Vulnerable Versions":"<3.0.3","Tree Versions":["3.0.2"],"Dependents":["micromatch@npm:4.0.5"]}}
+{"value":"cross-spawn","children":{"ID":1104664,"Issue":"Regular Expression Denial of Service (ReDoS) in cross-spawn","URL":"https://github.com/advisories/GHSA-3xgq-45jj-v275","Severity":"high","Vulnerable Versions":">=7.0.0 <7.0.5","Tree Versions":["7.0.3"],"Dependents":["foreground-child@npm:3.1.1"]}}
+{"value":"diff","children":{"ID":1112704,"Issue":"jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch","URL":"https://github.com/advisories/GHSA-73rr-hh4g-fpgx","Severity":"low","Vulnerable Versions":">=4.0.0 <4.0.4","Tree Versions":["4.0.2"],"Dependents":["ts-node@virtual:9201c3fcb1d2fc337a547d3e1e1ecdada20d4bdb2e59c3be026997a45afd9453374b37c3a876bd411e30a3314956039c4ef01c63ae83dddfcd7fe8ddf8896a6d#npm:10.9.2"]}}
+{"value":"flatted","children":{"ID":1114526,"Issue":"flatted vulnerable to unbounded recursion DoS in parse() revive phase","URL":"https://github.com/advisories/GHSA-25h7-pfq9-p65f","Severity":"high","Vulnerable Versions":"<3.4.0","Tree Versions":["3.3.1"],"Dependents":["flat-cache@npm:5.0.0"]}}
+{"value":"flatted","children":{"ID":1115357,"Issue":"Prototype Pollution via parse() in NodeJS flatted","URL":"https://github.com/advisories/GHSA-rf6f-7fwh-wjgh","Severity":"high","Vulnerable Versions":"<=3.4.1","Tree Versions":["3.3.1"],"Dependents":["flat-cache@npm:5.0.0"]}}
+{"value":"form-data","children":{"ID":1109538,"Issue":"form-data uses unsafe random function in form-data for choosing boundary","URL":"https://github.com/advisories/GHSA-fjxv-7rqg-78g4","Severity":"critical","Vulnerable Versions":">=4.0.0 <4.0.4","Tree Versions":["4.0.0"],"Dependents":["superagent@npm:10.2.2"]}}
+{"value":"form-data","children":{"ID":1120743,"Issue":"form-data: CRLF injection in form-data via unescaped multipart field names and filenames","URL":"https://github.com/advisories/GHSA-hmw2-7cc7-3qxx","Severity":"high","Vulnerable Versions":">=4.0.0 <4.0.6","Tree Versions":["4.0.0","4.0.5"],"Dependents":["axios@npm:1.16.1","superagent@npm:10.2.2"]}}
+{"value":"glob","children":{"ID":1109842,"Issue":"glob CLI: Command injection via -c/--cmd executes matches with shell:true","URL":"https://github.com/advisories/GHSA-5j98-mcp5-4vw2","Severity":"high","Vulnerable Versions":">=10.2.0 <10.5.0","Tree Versions":["10.4.5"],"Dependents":["node-gyp@npm:10.0.1"]}}
+{"value":"glob","children":{"ID":"glob (deprecation)","Issue":"Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me","Severity":"moderate","Vulnerable Versions":"11.1.0","Tree Versions":["11.1.0"],"Dependents":["sds-toffee-frontend@workspace:."]}}
+{"value":"ip-address","children":{"ID":1118827,"Issue":"ip-address has XSS in Address6 HTML-emitting methods","URL":"https://github.com/advisories/GHSA-v2v4-37r5-5v8g","Severity":"moderate","Vulnerable Versions":"<=10.1.0","Tree Versions":["9.0.5"],"Dependents":["socks@npm:2.8.1"]}}
+{"value":"js-yaml","children":{"ID":1112715,"Issue":"js-yaml has prototype pollution in merge (<<)","URL":"https://github.com/advisories/GHSA-mh29-5h37-fv8m","Severity":"moderate","Vulnerable Versions":">=4.0.0 <4.1.1","Tree Versions":["4.1.0"],"Dependents":["@hmcts/info-provider@npm:1.2.2"]}}
+{"value":"js-yaml","children":{"ID":1120792,"Issue":"JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases","URL":"https://github.com/advisories/GHSA-h67p-54hq-rp68","Severity":"moderate","Vulnerable Versions":"<=4.1.1","Tree Versions":["4.1.0","4.1.1"],"Dependents":["@hmcts/info-provider@npm:1.2.2","sds-toffee-frontend@workspace:."]}}
+{"value":"jws","children":{"ID":1111243,"Issue":"auth0/node-jws Improperly Verifies HMAC Signature","URL":"https://github.com/advisories/GHSA-869p-cjfg-cm3x","Severity":"high","Vulnerable Versions":"=4.0.0","Tree Versions":["4.0.0"],"Dependents":["@azure/identity@npm:4.4.0"]}}
+{"value":"jws","children":{"ID":1111244,"Issue":"auth0/node-jws Improperly Verifies HMAC Signature","URL":"https://github.com/advisories/GHSA-869p-cjfg-cm3x","Severity":"high","Vulnerable Versions":"<3.2.3","Tree Versions":["3.2.2"],"Dependents":["jsonwebtoken@npm:9.0.2"]}}
+{"value":"micromatch","children":{"ID":1098681,"Issue":"Regular Expression Denial of Service (ReDoS) in micromatch","URL":"https://github.com/advisories/GHSA-952p-6rrq-rcjv","Severity":"moderate","Vulnerable Versions":"<4.0.8","Tree Versions":["4.0.5"],"Dependents":["fast-glob@npm:3.3.2"]}}
+{"value":"nanoid","children":{"ID":1109563,"Issue":"Predictable results in nanoid generation when given non-integer values","URL":"https://github.com/advisories/GHSA-mwcw-c2x4-8c55","Severity":"moderate","Vulnerable Versions":"<3.3.8","Tree Versions":["3.3.7"],"Dependents":["postcss@npm:8.4.49"]}}
+{"value":"path-to-regexp","children":{"ID":1115527,"Issue":"path-to-regexp vulnerable to Regular Expression Denial of Service via multiple route parameters","URL":"https://github.com/advisories/GHSA-37ch-88jc-xwx2","Severity":"high","Vulnerable Versions":"<0.1.13","Tree Versions":["0.1.12"],"Dependents":["express@npm:4.21.2"]}}
+{"value":"picomatch","children":{"ID":1115549,"Issue":"Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching","URL":"https://github.com/advisories/GHSA-3v7f-55p6-f55p","Severity":"moderate","Vulnerable Versions":"<2.3.2","Tree Versions":["2.3.1"],"Dependents":["micromatch@npm:4.0.8"]}}
+{"value":"picomatch","children":{"ID":1115552,"Issue":"Picomatch has a ReDoS vulnerability via extglob quantifiers","URL":"https://github.com/advisories/GHSA-c2c7-rcm5-vvqj","Severity":"high","Vulnerable Versions":"<2.3.2","Tree Versions":["2.3.1"],"Dependents":["micromatch@npm:4.0.8"]}}
+{"value":"postcss","children":{"ID":1117015,"Issue":"PostCSS has XSS via Unescaped </style> in its CSS Stringify Output","URL":"https://github.com/advisories/GHSA-qx2v-qp2m-jg93","Severity":"moderate","Vulnerable Versions":"<8.5.10","Tree Versions":["8.4.49"],"Dependents":["stylelint@npm:16.11.0"]}}
+{"value":"protobufjs","children":{"ID":1120742,"Issue":"protobufjs : Schema-derived names can shadow runtime-significant properties","URL":"https://github.com/advisories/GHSA-f38q-mgvj-vph7","Severity":"moderate","Vulnerable Versions":"<=7.6.2","Tree Versions":["7.5.8"],"Dependents":["@opentelemetry/otlp-transformer@virtual:dc4f33283132acd76fe3b0b495949c3deecf704910c95fe9d6987151a63dd3e5449e2a3a1c0ca439e1094c5f5c83d7bd1984972ca976fc85356cea3d777d742e#npm:0.57.2"]}}
+{"value":"protobufjs","children":{"ID":1120799,"Issue":"protobufjs: Denial of service through unbounded Any expansion during JSON conversion","URL":"https://github.com/advisories/GHSA-wcpc-wj8m-hjx6","Severity":"high","Vulnerable Versions":"<=7.6.0","Tree Versions":["7.5.8"],"Dependents":["@opentelemetry/otlp-transformer@virtual:dc4f33283132acd76fe3b0b495949c3deecf704910c95fe9d6987151a63dd3e5449e2a3a1c0ca439e1094c5f5c83d7bd1984972ca976fc85356cea3d777d742e#npm:0.57.2"]}}
+{"value":"qs","children":{"ID":1113161,"Issue":"qs's arrayLimit bypass in comma parsing allows denial of service","URL":"https://github.com/advisories/GHSA-w7fw-mjwx-w883","Severity":"low","Vulnerable Versions":">=6.7.0 <=6.14.1","Tree Versions":["6.13.1"],"Dependents":["body-parser@npm:1.20.3"]}}
+{"value":"qs","children":{"ID":1113719,"Issue":"qs's arrayLimit bypass in its bracket notation allows DoS via memory exhaustion","URL":"https://github.com/advisories/GHSA-6rw7-vpxm-498p","Severity":"moderate","Vulnerable Versions":"<6.14.1","Tree Versions":["6.13.1"],"Dependents":["body-parser@npm:1.20.3"]}}
+{"value":"qs","children":{"ID":1119502,"Issue":"qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set","URL":"https://github.com/advisories/GHSA-q8mj-m7cp-5q26","Severity":"moderate","Vulnerable Versions":">=6.11.1 <=6.15.1","Tree Versions":["6.13.1"],"Dependents":["body-parser@npm:1.20.3"]}}
+{"value":"tar","children":{"ID":1097493,"Issue":"Denial of service while parsing a tar file due to lack of folders count validation","URL":"https://github.com/advisories/GHSA-f5x3-32g6-xq36","Severity":"moderate","Vulnerable Versions":"<6.2.1","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
+{"value":"tar","children":{"ID":1112659,"Issue":"node-tar Vulnerable to Arbitrary File Creation/Overwrite via Hardlink Path Traversal","URL":"https://github.com/advisories/GHSA-34x7-hfp2-rc4v","Severity":"high","Vulnerable Versions":"<7.5.7","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
+{"value":"tar","children":{"ID":1113300,"Issue":"node-tar is Vulnerable to Arbitrary File Overwrite and Symlink Poisoning via Insufficient Path Sanitization","URL":"https://github.com/advisories/GHSA-8qq5-rm4j-mr97","Severity":"high","Vulnerable Versions":"<=7.5.2","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
+{"value":"tar","children":{"ID":1113375,"Issue":"Arbitrary File Read/Write via Hardlink Target Escape Through Symlink Chain in node-tar Extraction","URL":"https://github.com/advisories/GHSA-83g3-92jg-28cx","Severity":"high","Vulnerable Versions":"<7.5.8","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
+{"value":"tar","children":{"ID":1114200,"Issue":"tar has Hardlink Path Traversal via Drive-Relative Linkpath","URL":"https://github.com/advisories/GHSA-qffp-2rhf-9h96","Severity":"high","Vulnerable Versions":"<=7.5.9","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
+{"value":"tar","children":{"ID":1114302,"Issue":"node-tar Symlink Path Traversal via Drive-Relative Linkpath","URL":"https://github.com/advisories/GHSA-9ppj-qmqm-q256","Severity":"high","Vulnerable Versions":"<=7.5.10","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
+{"value":"tar","children":{"ID":1114680,"Issue":"Race Condition in node-tar Path Reservations via Unicode Ligature Collisions on macOS APFS","URL":"https://github.com/advisories/GHSA-r6q2-hw4h-h46w","Severity":"high","Vulnerable Versions":"<=7.5.3","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
+{"value":"tar","children":{"ID":1120782,"Issue":"node-tar applies PAX size override to intermediary GNU long-name/long-link headers, causing tar parser interpretation differential (file smuggling)","URL":"https://github.com/advisories/GHSA-vmf3-w455-68vh","Severity":"moderate","Vulnerable Versions":"<=7.5.15","Tree Versions":["6.2.0"],"Dependents":["node-gyp@npm:10.0.1"]}}
+{"value":"undici","children":{"ID":1112496,"Issue":"Undici has an unbounded decompression chain in HTTP responses on Node.js Fetch API via Content-Encoding leads to resource exhaustion","URL":"https://github.com/advisories/GHSA-g9mf-h72j-4rw9","Severity":"moderate","Vulnerable Versions":"<6.23.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
+{"value":"undici","children":{"ID":1113069,"Issue":"undici Denial of Service attack via bad certificate data","URL":"https://github.com/advisories/GHSA-cxrh-j4jr-qwg3","Severity":"low","Vulnerable Versions":"<5.29.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
+{"value":"undici","children":{"ID":1114594,"Issue":"Undici has an HTTP Request/Response Smuggling issue","URL":"https://github.com/advisories/GHSA-2mjp-6q6p-2qxm","Severity":"moderate","Vulnerable Versions":"<6.24.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
+{"value":"undici","children":{"ID":1114638,"Issue":"Undici has Unbounded Memory Consumption in WebSocket permessage-deflate Decompression","URL":"https://github.com/advisories/GHSA-vrm6-8vpv-qv8q","Severity":"high","Vulnerable Versions":"<6.24.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
+{"value":"undici","children":{"ID":1114640,"Issue":"Undici has Unhandled Exception in WebSocket Client Due to Invalid server_max_window_bits Validation","URL":"https://github.com/advisories/GHSA-v9p9-hfj2-hcw8","Severity":"high","Vulnerable Versions":"<6.24.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
+{"value":"undici","children":{"ID":1114642,"Issue":"Undici has CRLF Injection in undici via `upgrade` option","URL":"https://github.com/advisories/GHSA-4992-7rv2-5pvq","Severity":"moderate","Vulnerable Versions":"<6.24.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
+{"value":"undici","children":{"ID":1121242,"Issue":"undici vulnerable to HTTP header injection via Set-Cookie percent-decoding","URL":"https://github.com/advisories/GHSA-p88m-4jfj-68fv","Severity":"moderate","Vulnerable Versions":"<6.27.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
+{"value":"undici","children":{"ID":1121245,"Issue":"undici WebSocket client vulnerable to denial of service via fragment count bypass","URL":"https://github.com/advisories/GHSA-vxpw-j846-p89q","Severity":"high","Vulnerable Versions":"<6.27.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
+{"value":"undici","children":{"ID":1121250,"Issue":"undici vulnerable to HTTP response queue poisoning via keep-alive socket reuse","URL":"https://github.com/advisories/GHSA-35p6-xmwp-9g52","Severity":"low","Vulnerable Versions":"<6.27.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
+{"value":"undici","children":{"ID":1121255,"Issue":"undici vulnerable to Set-Cookie SameSite attribute downgrade via permissive substring matching","URL":"https://github.com/advisories/GHSA-g8m3-5g58-fq7m","Severity":"low","Vulnerable Versions":"<6.27.0","Tree Versions":["5.28.5"],"Dependents":["@azure/functions@npm:4.6.1"]}}
+{"value":"uuid","children":{"ID":1119441,"Issue":"uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided","URL":"https://github.com/advisories/GHSA-w5hq-g745-h8pq","Severity":"moderate","Vulnerable Versions":"<11.1.1","Tree Versions":["3.4.0","8.3.2"],"Dependents":["@azure/functions@npm:3.5.1","allure-js-commons@npm:1.3.2"]}}


### PR DESCRIPTION
Updates Jenkinsfiles to use `Infrastructure@2.2.0` so the pipeline can be validated against the fixed env-agent rollout tag.

No application code changes.
