### PR TITLE
Reorder preset extends in renovate config so most general are first and then more specific last to match renovate logic

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,24 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>hmcts/.github//renovate/cnp-jenkins-library",
+    "local>hmcts/.github:renovate-config",
     "github>hmcts/.github//renovate/automerge-all",
-    "local>hmcts/.github:renovate-config"
+    "github>hmcts/.github//renovate/cnp-jenkins-library"
   ],
   "internalChecksFilter": "strict",
   "packageRules": [
-    {
-      "matchPackagePatterns": ["Jenkins-.*"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "pr"
-    },
-    {
-      "matchPackagePatterns": ["Jenkins-.*"],
-      "matchUpdateTypes": ["major"],
-      "automerge": false,
-      "platformAutomerge": false
-    },
     {
       "matchPackageNames": ["copy-webpack-plugin"],
       "allowedVersions": "<=10",


### PR DESCRIPTION
### Change description

- Reorder preset extends in renovate config so most general are first and then more specific last to match renovate logic
- Remove redundant package rules for cnp-jenkins-library as this has been fixed to already target jenkins lib dep only

### Testing done

n/a

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
